### PR TITLE
Add the "scores" paper to the "references and further reading" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3081,7 +3081,7 @@ storm-tracking algorithms. <i>Wea. Forecasting</i>, <b>25</b>, 701-709.
 N. Ramanathan, M. Carroll, S. Chong, A. Griffiths, and J. Sharples, 2024: 
 scores: A Python package for verifying and evaluating models and predictions 
 with xarray. <i>J. Open Source Software</i>, <b>9</b>, 6889, 
-<a href="https://doi.org/10.21105/joss.06889">https://doi.org/10.21105/joss.06889</a>
+<a href="https://doi.org/10.21105/joss.06889">https://doi.org/10.21105/joss.06889</a>.
 </p>
 <p>Legates, D.R. and G. J. McCabe Jr., 1999: Evaluating the use of "goodness-of-fit"
 measures in hydrologic and hydroclimatic model validation. <i>Water
@@ -3508,6 +3508,7 @@ Last updated: 4 August 2024
 
 
 </html>
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -2379,7 +2379,7 @@ with NetCDF4, HDF5, Zarr and GRIB data formats among others. It uses Dask for sc
 and performance. Some metrics also work with pandas. All of the metrics have undergone 
 a thorough scientific and software review. Every score has a companion Jupyter Notebook 
 tutorial that demonstrates its use in practice.</p>
-<p>The journal paper (Leeuwenburg et al. 2024) is available here: 
+<p>The journal paper <a href="index.html#Leeuwenburg_et_at_2024">(Leeuwenburg et al., 2024)</a> is available here: 
 <a href='https://doi.org/10.21105/joss.06889'>https://doi.org/10.21105/joss.06889</a>.
 The code is available here: <a href="https://github.com/nci/scores/">https://github.com/nci/scores/</a>
 and the documentation is available here: <a href="https://scores.readthedocs.io/">https://scores.readthedocs.io/</a>.
@@ -3077,7 +3077,7 @@ verification. <i>Wea. Forecasting</i>, <b>25</b>, 908-920.
 <p>Lakshmanan, V. and T. Smith, 2010: An objective method of evaluating and devising 
 storm-tracking algorithms. <i>Wea. Forecasting</i>, <b>25</b>, 701-709. 
 </p>
-<p>Leeuwenburg, T., N. Loveday, E.E. Ebert, H. Cook, M. Khanarmuei, R.J. Taggart, 
+<p><a id="Leeuwenburg_et_at_2024"></a>Leeuwenburg, T., N. Loveday, E.E. Ebert, H. Cook, M. Khanarmuei, R.J. Taggart, 
 N. Ramanathan, M. Carroll, S. Chong, A. Griffiths, and J. Sharples, 2024: 
 scores: A Python package for verifying and evaluating models and predictions 
 with xarray. <i>J. Open Source Software</i>, <b>9</b>, 6889, 
@@ -3508,5 +3508,6 @@ Last updated: 4 August 2024
 
 
 </html>
+
 
 

--- a/index.html
+++ b/index.html
@@ -2363,7 +2363,7 @@ ranked probability score, and ranked probability skill score.<br>
 
 <h3><i>Scores</i></h3>
 <p>
-<a href="https://scores.readthedocs.io/en/stable/"><i>scores</i></a>
+<a href="https://scores.readthedocs.io/"><i>scores</i></a>
 is an open source Python package developed by the Bureau of Meteorology. 
 It contains mathematical functions for the verification, 
 evaluation and optimisation of forecasts, predictions or models. At present, <i>scores</i> 
@@ -2379,7 +2379,12 @@ with NetCDF4, HDF5, Zarr and GRIB data formats among others. It uses Dask for sc
 and performance. Some metrics also work with pandas. All of the metrics have undergone 
 a thorough scientific and software review. Every score has a companion Jupyter Notebook 
 tutorial that demonstrates its use in practice.</p>
-
+<p>The journal paper (Leeuwenburg et al. 2024) is available 
+here: <a href='https://doi.org/10.21105/joss.06889'>https://doi.org/10.21105/joss.06889</a>.</p>
+The code is available here: <a href="https://github.com/nci/scores/">https://github.com/nci/scores/</a>
+and the documentation is available here: <a href="https://scores.readthedocs.io/">https://scores.readthedocs.io/</a>.
+</p>
+	
 <h3><i>Model Evaluation Tools (MET)</i></h3>
 <p>
 The <a href="https://dtcenter.org/community-code/metplus">Model Evaluation Tools (MET)</a>
@@ -3503,3 +3508,4 @@ Last updated: 4 August 2024
 
 
 </html>
+

--- a/index.html
+++ b/index.html
@@ -2379,8 +2379,8 @@ with NetCDF4, HDF5, Zarr and GRIB data formats among others. It uses Dask for sc
 and performance. Some metrics also work with pandas. All of the metrics have undergone 
 a thorough scientific and software review. Every score has a companion Jupyter Notebook 
 tutorial that demonstrates its use in practice.</p>
-<p>The journal paper (Leeuwenburg et al. 2024) is available 
-here: <a href='https://doi.org/10.21105/joss.06889'>https://doi.org/10.21105/joss.06889</a>.</p>
+<p>The journal paper (Leeuwenburg et al. 2024) is available here: 
+<a href='https://doi.org/10.21105/joss.06889'>https://doi.org/10.21105/joss.06889</a>.
 The code is available here: <a href="https://github.com/nci/scores/">https://github.com/nci/scores/</a>
 and the documentation is available here: <a href="https://scores.readthedocs.io/">https://scores.readthedocs.io/</a>.
 </p>
@@ -3508,4 +3508,5 @@ Last updated: 4 August 2024
 
 
 </html>
+
 

--- a/index.html
+++ b/index.html
@@ -3072,6 +3072,12 @@ verification. <i>Wea. Forecasting</i>, <b>25</b>, 908-920.
 <p>Lakshmanan, V. and T. Smith, 2010: An objective method of evaluating and devising 
 storm-tracking algorithms. <i>Wea. Forecasting</i>, <b>25</b>, 701-709. 
 </p>
+<p>Leeuwenburg, T., N. Loveday, E.E. Ebert, H. Cook, M. Khanarmuei, R.J. Taggart, 
+N. Ramanathan, M. Carroll, S. Chong, A. Griffiths, and J. Sharples, 2024: 
+scores: A Python package for verifying and evaluating models and predictions 
+with xarray. <i>J. Open Source Software</i>, <b>9</b>, 6889, 
+<a href="https://doi.org/10.21105/joss.06889">https://doi.org/10.21105/joss.06889</a>
+</p>
 <p>Legates, D.R. and G. J. McCabe Jr., 1999: Evaluating the use of "goodness-of-fit"
 measures in hydrologic and hydroclimatic model validation. <i>Water
 Resour. Res.</i>, <b>35</b>, 233-241.
@@ -3494,5 +3500,6 @@ Last updated: 4 August 2024
 </div>
 
 </body>
+
 
 </html>


### PR DESCRIPTION
Fixes #8 

Add "scores" paper to the "references and further reading" section
Add the citation to the "scores" description in "Freely available verification tools and packages", as well as links to both the documentation and the source code, as that is what people mostly want.

I couldn't find a citation style guide, but it appeared to be the AMS style (https://www.ametsoc.org/ams/publications/author-information/formatting-and-manuscript-components/references/ ) so that is what I followed. It may be worth adding that to the contributor guide if that is the intention.

The Journal of Open Source Software did not have a journal abbreviation in the CAS Source Index. However, I noticed that other journal titles in the list did not abbreviate the words "open", "source" or "software", hence I used "J. Open Source Software".
