### PR TITLE
Update styling

### DIFF
--- a/default.css
+++ b/default.css
@@ -69,6 +69,13 @@ a:hover {
   text-decoration-thickness: 0.12em;
 }
 
+/* Legacy named anchors are sometimes used as wrappers around ordinary text.
+   They are targets, not links, so they should not inherit link colouring. */
+a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
 a:focus-visible,
 button:focus-visible,
 [tabindex]:focus-visible {
@@ -131,8 +138,50 @@ p.center {
 }
 
 p.green {
-  color: var(--color-example);
-  font-weight: 550;
+  max-width: 78ch;
+  margin: var(--space-5) 0 var(--space-6);
+  padding: 0.9rem var(--space-4);
+  border-left: 4px solid #49a99f;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: #e6f5f2;
+  color: #145e54;
+  font-weight: 600;
+}
+
+p.green::before {
+  display: block;
+  margin-bottom: var(--space-1);
+  color: var(--color-teal-700);
+  content: "Example result";
+  font-size: 0.72rem;
+  font-weight: 760;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.entry-divider {
+  width: min(100%, 78ch);
+  height: 1px;
+  margin: var(--space-7) 0 var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+.entry-heading {
+  max-width: 78ch;
+  margin-top: 0;
+  margin-bottom: var(--space-3);
+  line-height: 1.45;
+}
+
+.entry-heading .score-title,
+.entry-heading.score-title {
+  color: var(--color-navy-900);
+  font-size: 1.08rem;
+}
+
+b.entry-heading,
+strong.entry-heading {
+  display: block;
 }
 
 ul,
@@ -179,6 +228,52 @@ img.left {
 img.block {
   display: block;
   margin: var(--space-5) auto;
+}
+
+.content-figure {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: #f8faf9;
+}
+
+.content-figure:not(.content-figure--right):not(.content-figure--left) {
+  margin: var(--space-5) auto;
+}
+
+.content-figure--right {
+  float: right;
+  margin: var(--space-2) 0 var(--space-5) var(--space-6);
+}
+
+.content-figure--left {
+  float: left;
+  margin: var(--space-2) var(--space-6) var(--space-5) 0;
+}
+
+.content-figure img {
+  display: block;
+  margin: 0 auto;
+}
+
+.figure-pair {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  align-items: flex-start;
+  margin: var(--space-5) 0 var(--space-6);
+}
+
+.figure-pair .content-figure {
+  float: none;
+  margin: 0;
+}
+
+.figure-pair .content-figure:not(.content-figure--right):not(.content-figure--left) {
+  margin: 0;
 }
 
 .table-scroll {
@@ -629,8 +724,9 @@ footer {
   }
 
   img.right,
-  img.left {
-    display: block;
+  img.left,
+  .content-figure--right,
+  .content-figure--left {
     float: none;
     margin: var(--space-5) auto;
   }
@@ -638,6 +734,18 @@ footer {
   div.flexbox,
   div[style*="display: flex"] {
     display: block !important;
+  }
+
+  .figure-pair {
+    display: block;
+  }
+
+  .figure-pair .content-figure {
+    margin: var(--space-5) auto;
+  }
+
+  .figure-pair .content-figure:not(.content-figure--right):not(.content-figure--left) {
+    margin: var(--space-5) auto;
   }
 
   .indented {

--- a/default.css
+++ b/default.css
@@ -1,143 +1,695 @@
-/* Typography and Headings */
-body {
-  font-family: Arial, Helvetica, sans-serif;
-  line-height: 1.4;
-  margin: 1em;
-}
-h2 {
-  border-bottom: 1px solid #ccc;
-  padding-bottom: 0.2em;
-  margin-top: 2em;
-}
-h3 {
-  padding-bottom: 0.2em;
-  margin-top: 2em;
-}
-h4 {
-  padding-bottom: 0.1em;
-  margin-top: 1em;
-  font-style: italic;
+:root {
+  --color-navy-950: #0b2438;
+  --color-navy-900: #11334d;
+  --color-blue-700: #176b8f;
+  --color-blue-600: #197ea3;
+  --color-teal-700: #087b78;
+  --color-text: #243540;
+  --color-text-muted: #5c6d76;
+  --color-link: #096b91;
+  --color-link-hover: #075574;
+  --color-page: #f4f7f8;
+  --color-surface: #fffefa;
+  --color-sidebar: #eaf1f4;
+  --color-border: #cad7dc;
+  --color-border-subtle: #dde6e9;
+  --color-table-head: #e7f1f4;
+  --color-example: #116b55;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --shadow-focus: 0 0 0 3px rgba(25, 126, 163, 0.3);
+  --sidebar-width: 284px;
+  --content-width: 960px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4.5rem;
 }
 
-/* Paragraph Formatting */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: var(--space-5);
+}
+
+body {
+  min-width: 0;
+  margin: 0;
+  overflow-x: hidden;
+  background: var(--color-page);
+  color: var(--color-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: clamp(1rem, 0.97rem + 0.12vw, 1.0625rem);
+  line-height: 1.68;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: #c5e7ee;
+  color: var(--color-navy-950);
+}
+
+a {
+  color: var(--color-link);
+  text-decoration-thickness: 0.075em;
+  text-underline-offset: 0.16em;
+}
+
+a:hover {
+  color: var(--color-link-hover);
+  text-decoration-thickness: 0.12em;
+}
+
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-blue-600);
+  outline-offset: 3px;
+  box-shadow: var(--shadow-focus);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  color: var(--color-navy-950);
+  font-weight: 690;
+  line-height: 1.22;
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: var(--space-7) 0 0;
+  font-size: clamp(2.2rem, 1.7rem + 2.2vw, 4rem);
+  letter-spacing: -0.035em;
+}
+
+h2 {
+  margin: var(--space-8) 0 var(--space-5);
+  padding: 0 0 var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  font-size: clamp(1.55rem, 1.42rem + 0.55vw, 1.95rem);
+  letter-spacing: -0.018em;
+}
+
+h3 {
+  margin: var(--space-7) 0 var(--space-3);
+  font-size: clamp(1.2rem, 1.14rem + 0.25vw, 1.4rem);
+}
+
+h4 {
+  margin: var(--space-6) 0 var(--space-2);
+  font-size: 1.08rem;
+}
+
+h1[id],
+h2[id],
+h3[id],
+h4[id],
+a[id] {
+  scroll-margin-top: var(--space-6);
+}
+
+p {
+  max-width: 78ch;
+  margin: 0 0 var(--space-4);
+}
+
 p.center {
   text-align: center;
 }
+
 p.green {
-  color: #04BD1C;
+  color: var(--color-example);
+  font-weight: 550;
 }
 
-/* Lists */
-ul.spaced li {
-  margin-bottom: 0.5em;
+ul,
+ol {
+  max-width: 78ch;
+  padding-left: 1.6em;
 }
+
+li + li {
+  margin-top: var(--space-2);
+}
+
+ul.spaced li,
+ul.dot-points li,
+.spaced-list li {
+  margin-bottom: var(--space-3);
+}
+
 ul.dot-points li {
-  margin-bottom: 0.5em;
   list-style-type: disc;
 }
 
-/* Images */
-img.right {
-  float: right;
-  margin-left: 20px;
-  margin-bottom: 10px;
-}
-img.left {
-  float: left;
-  margin-right: 20px;
-  margin-bottom: 10px;
-}
-img.block {
-  display: block;
-  margin: 0 auto;
+hr {
+  margin: var(--space-7) 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
 }
 
-/* Tables */
-table {
-  margin: 1em 0;
+img {
+  max-width: 100%;
+  height: auto;
 }
-table.left-aligned-table td, 
+
+img.right {
+  float: right;
+  margin: var(--space-2) 0 var(--space-5) var(--space-6);
+}
+
+img.left {
+  float: left;
+  margin: var(--space-2) var(--space-6) var(--space-5) 0;
+}
+
+img.block {
+  display: block;
+  margin: var(--space-5) auto;
+}
+
+.table-scroll {
+  width: 100%;
+  margin: var(--space-5) 0 var(--space-6);
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  -webkit-overflow-scrolling: touch;
+}
+
+table {
+  width: max-content;
+  min-width: min(100%, 42rem);
+  margin: 0;
+  border: 0;
+  border-collapse: collapse;
+  font-size: 0.94rem;
+  line-height: 1.48;
+}
+
+th,
+td {
+  padding: 0.72rem 0.9rem;
+  border: 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  text-align: center;
+  vertical-align: top;
+}
+
+th {
+  background: var(--color-table-head);
+  color: var(--color-navy-900);
+  font-weight: 700;
+}
+
+tr:last-child > td,
+tr:last-child > th {
+  border-bottom: 0;
+}
+
+tbody tr:nth-child(even):not(.green-cell):not(.lightgreen-cell) > td:not(.green-cell):not(.lightgreen-cell) {
+  background: #f8faf9;
+}
+
+table.left-aligned-table td,
 table.left-aligned-table th {
   text-align: left;
-  padding: 8px; 
-  border: 1px;
 }
-td, th {
-  text-align: center;
-  padding: 8px;  
-  border: 1px;
+
+/* The forecast-types table is a three-column reference table rather than a
+   dense data matrix, so keep it fluid at every viewport width. */
+table.left-aligned-table {
+  width: 100%;
+  min-width: 0;
+  table-layout: fixed;
 }
+
+table.left-aligned-table th:nth-child(1),
+table.left-aligned-table td:nth-child(1) {
+  width: 22%;
+}
+
+table.left-aligned-table th:nth-child(2),
+table.left-aligned-table td:nth-child(2) {
+  width: 28%;
+}
+
+table.left-aligned-table th:nth-child(3),
+table.left-aligned-table td:nth-child(3) {
+  width: 50%;
+}
+
+table.left-aligned-table th,
+table.left-aligned-table td {
+  overflow-wrap: anywhere;
+}
+
 .green-cell {
   background-color: #33ff33;
 }
+
 .lightgreen-cell {
   background-color: #99ff99;
 }
 
-/* Utility */
+.equation {
+  max-width: 100%;
+  overflow-x: auto;
+  padding: var(--space-2) 0;
+  -webkit-overflow-scrolling: touch;
+}
+
 div.flexbox {
-  display: flex;            /* allows images and text to be vertically centered */
+  display: flex;
+  gap: var(--space-5);
   align-items: center;
 }
+
 .no-border {
   border: none !important;
 }
+
 .no-margin {
   margin: 0 !important;
 }
+
 .centered {
   text-align: center;
 }
+
 .indented {
   margin-left: 2em;
 }
 
-#main-content {
-   margin-left: 240px;
-   padding: 2em;
+.skip-link {
+  position: fixed;
+  z-index: 1000;
+  top: var(--space-3);
+  left: var(--space-3);
+  translate: 0 -180%;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  background: var(--color-navy-950);
+  color: white;
+  font-weight: 700;
 }
+
+.skip-link:focus {
+  translate: 0;
+}
+
+#main-content {
+  width: min(calc(100% - var(--sidebar-width)), var(--content-width));
+  min-width: 0;
+  margin-left: var(--sidebar-width);
+  padding: var(--space-7) clamp(var(--space-5), 4vw, var(--space-8)) var(--space-8);
+  background: var(--color-surface);
+  box-shadow: 1px 0 0 var(--color-border-subtle), -1px 0 0 var(--color-border-subtle);
+  overflow-wrap: break-word;
+}
+
+#main-content > section {
+  display: flow-root;
+}
+
+.site-header {
+  margin: calc(-1 * var(--space-7)) clamp(calc(-1 * var(--space-8)), -4vw, calc(-1 * var(--space-5))) 0;
+  padding: var(--space-6) clamp(var(--space-5), 4vw, var(--space-8)) var(--space-7);
+  border-top: 5px solid var(--color-teal-700);
+  border-bottom: 1px solid var(--color-border);
+  background: #eef5f6;
+}
+
+.logo-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5) var(--space-6);
+  align-items: center;
+}
+
+.logo-group a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 3rem;
+}
+
+.logo-group img {
+  width: auto;
+  max-width: min(15rem, 35vw);
+  max-height: 4.75rem;
+  object-fit: contain;
+}
+
 #sidebar {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 230px;
-  height: 100%;
-  background-color: #f8f8f8;
-  border-right: 1px solid #ddd;
-  padding: 1em;
+  z-index: 20;
+  inset: 0 auto 0 0;
+  width: var(--sidebar-width);
   overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--space-6) var(--space-4) var(--space-7);
+  border-right: 1px solid var(--color-border);
+  background: var(--color-sidebar);
+  scrollbar-color: #9ab1ba transparent;
 }
+
 #sidebar h2 {
-  font-size: 1.1em;
-  margin-top: 0;
+  margin: 0 0 var(--space-4);
+  padding: 0 var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.78rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
 }
+
 #sidebar ul {
-  font-size: 0.9rem;
-  line-height: 1.0rem;
+  max-width: none;
+  margin: 0;
+  padding: 0;
   list-style: none;
-  padding-left: 0;
+  font-size: 0.89rem;
+  line-height: 1.34;
 }
-#sidebar li {
-  margin: 0.5em 0;
+
+#sidebar li,
+#sidebar li + li {
+  margin: 0;
 }
+
 #sidebar ul ul {
-  margin-left: 0.5em; /* Adjust indent here */
-  padding-left: 0.5em;
+  margin: var(--space-1) 0 var(--space-2) var(--space-3);
+  padding-left: var(--space-3);
+  border-left: 1px solid #b9cbd1;
+  font-size: 0.84rem;
 }
+
 #sidebar a {
+  display: block;
+  margin: 1px 0;
+  padding: 0.48rem 0.62rem;
+  border-radius: var(--radius-sm);
+  color: #344e5c;
   text-decoration: none;
-  color: #333;
 }
+
+#sidebar > nav > ul > li > a {
+  color: var(--color-navy-900);
+  font-weight: 650;
+}
+
 #sidebar a:hover {
-  text-decoration: underline;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--color-link-hover);
+}
+
+#sidebar a[aria-current="location"] {
+  background: white;
+  color: var(--color-teal-700);
+  box-shadow: inset 3px 0 0 var(--color-teal-700);
+  font-weight: 700;
+}
+
+.mobile-nav-bar,
+.nav-scrim {
+  display: none;
+}
+
+.back-to-top {
+  position: fixed;
+  z-index: 12;
+  display: none;
+  right: var(--space-5);
+  bottom: var(--space-5);
+  translate: 0 calc(100% + var(--space-7));
+  padding: 0.62rem 0.85rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 254, 250, 0.96);
+  color: var(--color-navy-900);
+  box-shadow: 0 2px 8px rgba(11, 36, 56, 0.12);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-decoration: none;
+  opacity: 0;
+  transition: translate 160ms ease, opacity 160ms ease;
+}
+
+.js .back-to-top {
+  display: block;
+}
+
+.back-to-top.is-visible {
+  translate: 0;
+  opacity: 1;
+}
+
+footer {
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+}
+
+@media (min-width: 1245px) {
+  #main-content {
+    margin-left: max(var(--sidebar-width), calc((100vw - var(--sidebar-width) - var(--content-width)) / 2 + var(--sidebar-width)));
+  }
+}
+
+@media (max-width: 900px) {
+  html {
+    scroll-padding-top: 5rem;
+  }
+
+  body.nav-open {
+    overflow: hidden;
+  }
+
+  .mobile-nav-bar {
+    position: sticky;
+    z-index: 45;
+    top: 0;
+    display: flex;
+    min-height: 3.75rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: rgba(244, 247, 248, 0.97);
+    backdrop-filter: blur(8px);
+  }
+
+  .mobile-site-name {
+    overflow: hidden;
+    color: var(--color-navy-900);
+    font-size: 0.88rem;
+    font-weight: 720;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .contents-toggle {
+    display: inline-flex;
+    min-height: 2.75rem;
+    flex: none;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: white;
+    color: var(--color-navy-900);
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .contents-toggle-icon,
+  .contents-toggle-icon::before,
+  .contents-toggle-icon::after {
+    display: block;
+    width: 1rem;
+    height: 2px;
+    background: currentColor;
+    content: "";
+  }
+
+  .contents-toggle-icon {
+    position: relative;
+  }
+
+  .contents-toggle-icon::before {
+    position: absolute;
+    top: -5px;
+  }
+
+  .contents-toggle-icon::after {
+    position: absolute;
+    top: 5px;
+  }
+
+  #sidebar {
+    z-index: 40;
+    inset: 3.75rem auto 0 0;
+    width: min(22rem, calc(100vw - 3rem));
+    padding-top: var(--space-5);
+    box-shadow: 8px 0 24px rgba(11, 36, 56, 0.2);
+    translate: -105% 0;
+    visibility: hidden;
+    transition: translate 180ms ease, visibility 180ms;
+  }
+
+  body.nav-open #sidebar {
+    translate: 0;
+    visibility: visible;
+  }
+
+  .nav-scrim {
+    position: fixed;
+    z-index: 35;
+    inset: 0;
+    width: 100%;
+    border: 0;
+    background: rgba(11, 36, 56, 0.4);
+    cursor: pointer;
+  }
+
+  body.nav-open .nav-scrim {
+    display: block;
+  }
+
+  #main-content {
+    width: 100%;
+    margin-left: 0;
+    padding-top: var(--space-6);
+    box-shadow: none;
+  }
+
+  .site-header {
+    margin-top: calc(-1 * var(--space-6));
+  }
+
+  h1[id],
+  h2[id],
+  h3[id],
+  h4[id],
+  a[id] {
+    scroll-margin-top: 5rem;
+  }
+}
+
+@media (max-width: 600px) {
+  #main-content {
+    padding-right: var(--space-4);
+    padding-left: var(--space-4);
+  }
+
+  .site-header {
+    margin-right: calc(-1 * var(--space-4));
+    margin-left: calc(-1 * var(--space-4));
+    padding-right: var(--space-4);
+    padding-left: var(--space-4);
+  }
+
+  .logo-group {
+    gap: var(--space-3) var(--space-5);
+  }
+
+  .logo-group img {
+    max-width: min(10rem, 38vw);
+    max-height: 3.8rem;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 10vw, 2.7rem);
+  }
+
+  h2 {
+    margin-top: var(--space-7);
+  }
+
+  img.right,
+  img.left {
+    display: block;
+    float: none;
+    margin: var(--space-5) auto;
+  }
+
+  div.flexbox,
+  div[style*="display: flex"] {
+    display: block !important;
+  }
+
+  .indented {
+    margin-left: var(--space-4);
+  }
+
+  .back-to-top {
+    right: var(--space-4);
+    bottom: var(--space-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }
 
 @media print {
-  #sidebar {
-    display: none;
+  body {
+    background: white;
+    color: black;
+    font-size: 11pt;
   }
+
+  #sidebar,
+  .mobile-nav-bar,
+  .nav-scrim,
+  .back-to-top,
+  .skip-link {
+    display: none !important;
+  }
+
   #main-content {
+    width: auto;
+    max-width: none;
     margin: 0;
     padding: 0;
+    box-shadow: none;
+  }
+
+  .site-header {
+    margin: 0;
+    padding: 0 0 1rem;
+    background: white;
+  }
+
+  .table-scroll,
+  .equation {
+    overflow: visible;
   }
 }

--- a/default.css
+++ b/default.css
@@ -273,6 +273,12 @@ table.left-aligned-table td {
   -webkit-overflow-scrolling: touch;
 }
 
+@media (min-width: 901px) {
+  html.equations-fit-ready .equation {
+    overflow-x: hidden;
+  }
+}
+
 div.flexbox {
   display: flex;
   gap: var(--space-5);

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Verification FAQ</title>
   <!-- IMPORTANT - THIS CSS FILE DEFINES THE STYLES USED IN THE PAGE -->
   <!-- WHEN YOU SEE class="..." IN INDEX.HTML, LOOK IN THE CSS FILE FOR A DESCRIPTION -->
@@ -16,8 +17,20 @@
 
 <body>
 
-  <div id="sidebar">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <div class="mobile-nav-bar">
+    <span class="mobile-site-name">JWGFVR Forecast Verification</span>
+    <button id="contents-toggle" class="contents-toggle" type="button" aria-expanded="false"
+      aria-controls="sidebar">
+      <span class="contents-toggle-icon" aria-hidden="true"></span>
+      Contents
+    </button>
+  </div>
+
+  <aside id="sidebar" aria-label="Document contents">
     <h2>Contents</h2>
+    <nav aria-label="On this page">
     <ul>
       <li><a href="#Purpose">What is this website about?</a></li>
       <li><a href="#Definition">What is forecast verification?</a>
@@ -65,16 +78,20 @@
       <li><a href="#Contributors">Contributors to this site</a></li>
       <!--<li><a href="#Art">Verification and art</a></li>-->
     </ul>
-  </div>
+    </nav>
+  </aside>
 
-  <div id="main-content">
+  <button class="nav-scrim" type="button" aria-label="Close contents" tabindex="-1"></button>
+
+  <main id="main-content" tabindex="-1">
 
     <!----------------------------------------------------------------------------------------------------------------------------->
-    <section>
+    <section class="site-header" aria-labelledby="page-title">
       <!--- Page header --------------------------------------------------------------------------------------------------->
       <!----------------------------------------------------------------------------------------------------------------------------->
 
       <!-- Logos -->
+      <div class="logo-group" aria-label="Partner organisations">
       <a
         href="https://community.wmo.int/en/activity-areas/wwrp/wwrp-working-groups/wwrp-forecast-verification-research">
         <img alt="JWGFVR logo" src="site/JWGFVR-logo-250.png" height="90"></a>
@@ -82,6 +99,7 @@
         <img alt="WWRP logo" src="site/WWRPlogo.gif" height="90"></a>
       <a href="https://www.wcrp-climate.org/">
         <img alt="WCRP logo" src="site/WCRP_logo.jpg" height="90"></a>
+      </div>
       <!--<hr>-->
 
       <!-- UNCOMMENT AND USE THIS SECTION TO PROMOTE NEWS, ETC. -->
@@ -95,7 +113,7 @@ More scores:<br>
 <hr>
 -->
 
-      <h1>Forecast verification - methods, issues and FAQ</h1>
+      <h1 id="page-title">Forecast verification - methods, issues and FAQ</h1>
 
     </section>
 
@@ -3702,7 +3720,11 @@ THERE USED TO BE LINKS TO VERIFICATION BLUES HERE
       </p>
     </footer>
 
-  </div>
+  </main>
+
+  <a class="back-to-top" href="#page-title" aria-label="Back to top">Back to top</a>
+
+  <script src="site.js"></script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
   <!-- WHEN YOU SEE class="..." IN INDEX.HTML, LOOK IN THE CSS FILE FOR A DESCRIPTION -->
   <link rel="stylesheet" href="default.css">
   <!-- MathJax for rendering mathematical equations -->
+  <script>
+    window.MathJax = {
+      chtml: {
+        linebreaks: {
+          automatic: true,
+          width: "container"
+        }
+      }
+    };
+  </script>
   <script id="MathJax-script" async
     src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js"
     integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei"

--- a/index.html
+++ b/index.html
@@ -499,11 +499,12 @@ More scores:<br>
         fashioned visual, or "eyeball", method: look at the forecast and observations
         side by side and use human judgment to discern the forecast errors. Common
         ways to present data are as time series and maps.
-      </p><br>
-      <img src="site/timeseries.gif" alt="Time series of temperature forecasts and observations" width="372"
-        height="178" class="left">
-      <img src="site/DWDmaps.gif" alt="Rainfall forecast and observations" width="320" height="152"
-        style="margin-bottom: 25px;">
+      </p>
+      <div class="figure-pair">
+        <img src="site/timeseries.gif" alt="Time series of temperature forecasts and observations" width="372"
+          height="178" class="left">
+        <img src="site/DWDmaps.gif" alt="Rainfall forecast and observations" width="320" height="152">
+      </div>
       <p>
         The eyeball method is great if you only have a few forecasts, or you
         have lots of time, or you're not interested in quantitative verification
@@ -1799,7 +1800,7 @@ More scores:<br>
             developed scientific and diagnostic methods, and relies heavily on references and
             links to other sites with greater detail.
           </p>
-          <p style="color: blue;"><b><i>This is also a place to promote new
+          <p><b><i>This is also a place to promote new
                 verification techniques. If you are working in this area, then you are encouraged to
                 share your methods via this web site.</i></b>
           </p>
@@ -2296,7 +2297,7 @@ More scores:<br>
           root-mean-square difference, and standard deviation (<a href="index.html#Taylor_2001">Taylor 2001</a>); see
           also <a href="https://pcmdi.llnl.gov/staff/taylor/CV/Taylor_diagram_primer.pdf">
             LLNL description</a>. An example of a Taylor diagram is shown at right.</p>
-        <img src="site/TaylorDiagram.gif" alt="Taylor diagram example" width="347" height="331">
+        <img src="site/TaylorDiagram.gif" alt="Taylor diagram example" width="570" height="545">
       </div>
       <p>- - - - - - - - - - -
       </p>
@@ -2408,14 +2409,14 @@ More scores:<br>
       <img src="site/DetLim.gif" alt="Deterministic limit diagram" width="320" height="237" class="right">
       <p><b><i><a href="site/Hewson/DeterministicLimit.html">
               Deterministic limit</a></i></b> <a href="index.html#Hewson2007">(Hewson, 2007)</a></p>
-      <p><a><b>Answers the question:</b><i> What is the length of time into the forecast
+      <p><b>Answers the question:</b><i> What is the length of time into the forecast
             in which the forecast is more likely to be correct than incorrect?</i>
-        </a></p>
-      <p><a>The 'deterministic limit' is defined, for
+      </p>
+      <p>The 'deterministic limit' is defined, for
           categorical forecasts of a pre-defined rare meteorological event, to
           simply be the point ahead of issue time at which, across the
           population, the number of misses plus false alarms equals the number of
-          hits (i.e. </a><a href="index.html#CSI">critical success index</a>
+          hits (i.e. <a href="index.html#CSI">critical success index</a>
         =0.5). A hypothetical example of an accuracy statement that might thus
         arise would be: 'The deterministic limit for predicting a windstorm,
         with gusts in excess of 60 kts at one or more low-lying inland stations

--- a/reference.css
+++ b/reference.css
@@ -45,6 +45,49 @@ body font {
   font-family: inherit;
 }
 
+.reference-header {
+  max-width: 78ch;
+  margin: 0 auto clamp(2rem, 4vw, 3.5rem);
+  padding-bottom: clamp(1.5rem, 3vw, 2.25rem);
+  border-bottom: 1px solid var(--reference-border);
+  text-align: center;
+}
+
+.reference-breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 1.25rem;
+  color: #087b78;
+  font-size: 0.8rem;
+  font-weight: 720;
+  letter-spacing: 0.055em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.reference-breadcrumb::before {
+  content: "\2190";
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.reference-breadcrumb:hover {
+  text-decoration: underline;
+}
+
+.reference-header h1 {
+  margin-bottom: 1rem;
+}
+
+.reference-byline {
+  max-width: 60ch;
+  margin: 0 auto;
+  color: #5c6d76;
+  font-size: 0.94rem;
+  line-height: 1.5;
+}
+
 body h1,
 body h2,
 body h3,

--- a/reference.css
+++ b/reference.css
@@ -1,0 +1,195 @@
+/* Shared presentation for the legacy reference pages linked from the FAQ. */
+
+:root {
+  --reference-page: #f4f7f8;
+  --reference-surface: #fffefa;
+  --reference-text: #243540;
+  --reference-navy: #0b2438;
+  --reference-link: #096b91;
+  --reference-border: #cad7dc;
+  --reference-border-subtle: #dde6e9;
+  --reference-table-head: #e7f1f4;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 0;
+  background: var(--reference-page);
+  scroll-behavior: smooth;
+}
+
+/* This stylesheet is loaded only by standalone reference pages, so a plain
+   body selector lets it support their varied legacy body markup. */
+body {
+  width: min(100%, 960px);
+  min-width: 0;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 4.5rem) clamp(1.25rem, 4vw, 4.5rem);
+  border-top: 5px solid #087b78;
+  background: var(--reference-surface);
+  color: var(--reference-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: clamp(1rem, 0.97rem + 0.12vw, 1.0625rem);
+  line-height: 1.68;
+  overflow-wrap: break-word;
+  text-rendering: optimizeLegibility;
+}
+
+body font {
+  font-family: inherit;
+}
+
+body h1,
+body h2,
+body h3,
+body h4 {
+  color: var(--reference-navy);
+  font-family: inherit;
+  line-height: 1.22;
+}
+
+body h1 {
+  max-width: 24ch;
+  margin: 0 auto 1.5rem;
+  font-size: clamp(1.9rem, 1.5rem + 1.8vw, 3.2rem);
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
+body h2 {
+  margin: 3.5rem 0 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--reference-border);
+  font-size: clamp(1.45rem, 1.3rem + 0.5vw, 1.9rem);
+}
+
+body h3 {
+  margin: 2.5rem 0 0.75rem;
+  font-size: clamp(1.2rem, 1.1rem + 0.3vw, 1.45rem);
+}
+
+body h4 {
+  margin: 2rem 0 0.5rem;
+  font-size: 1.08rem;
+}
+
+body p,
+body ul,
+body ol {
+  max-width: 78ch;
+}
+
+body p {
+  margin: 0 0 1rem;
+}
+
+body p[align="justify"] {
+  text-align: left;
+}
+
+body li + li {
+  margin-top: 0.5rem;
+}
+
+body center {
+  max-width: 78ch;
+  margin-right: auto;
+  margin-left: auto;
+  text-align: center;
+}
+
+body a {
+  color: var(--reference-link);
+  text-decoration-thickness: 0.075em;
+  text-underline-offset: 0.16em;
+}
+
+body a:hover {
+  color: #075574;
+  text-decoration-thickness: 0.12em;
+}
+
+body a:focus-visible {
+  outline: 2px solid #197ea3;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 3px rgba(25, 126, 163, 0.3);
+}
+
+body img {
+  max-width: 100%;
+  height: auto;
+}
+
+body table {
+  width: 100%;
+  max-width: 100%;
+  margin: 1.5rem 0 2rem;
+  border-collapse: collapse;
+  font-size: 0.94rem;
+  line-height: 1.48;
+}
+
+body th,
+body td {
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--reference-border-subtle);
+  vertical-align: top;
+}
+
+body th {
+  background: var(--reference-table-head);
+  color: var(--reference-navy);
+  font-weight: 700;
+}
+
+body hr {
+  margin: 3rem 0;
+  border: 0;
+  border-top: 1px solid var(--reference-border);
+}
+
+body .equation {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.25rem 1rem 3rem;
+  }
+
+  body h2 {
+    margin-top: 2.5rem;
+  }
+
+  body table {
+    display: block;
+    overflow-x: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  html {
+    background: white;
+  }
+
+  body {
+    width: auto;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    background: white;
+  }
+}

--- a/site.js
+++ b/site.js
@@ -89,6 +89,52 @@
   window.addEventListener("resize", updateScrollableTables);
   updateScrollableTables();
 
+  var equationFitFrame;
+
+  function fitDisplayEquations() {
+    var equations = document.querySelectorAll(".equation");
+    var isWideScreen = window.matchMedia("(min-width: 901px)").matches;
+    var renderedEquationCount = 0;
+
+    equations.forEach(function (equation) {
+      equation.style.removeProperty("font-size");
+      if (!isWideScreen) return;
+
+      var math = equation.querySelector("mjx-container[display=\"true\"] mjx-math");
+      if (!math || equation.clientWidth < 1) return;
+      renderedEquationCount += 1;
+
+      var availableWidth = equation.clientWidth;
+      var renderedWidth = math.getBoundingClientRect().width;
+      if (renderedWidth > availableWidth) {
+        equation.style.fontSize = (availableWidth / renderedWidth * 0.98) + "em";
+      }
+    });
+
+    document.documentElement.classList.toggle(
+      "equations-fit-ready",
+      isWideScreen && renderedEquationCount > 0
+    );
+  }
+
+  function scheduleEquationFit() {
+    if (equationFitFrame) window.cancelAnimationFrame(equationFitFrame);
+    equationFitFrame = window.requestAnimationFrame(fitDisplayEquations);
+  }
+
+  window.addEventListener("resize", scheduleEquationFit);
+  scheduleEquationFit();
+
+  if ("MutationObserver" in window) {
+    var equationObserver = new MutationObserver(scheduleEquationFit);
+    equationObserver.observe(document.getElementById("main-content"), {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  window.setTimeout(scheduleEquationFit, 1500);
+
   var navLinks = Array.from(sidebar.querySelectorAll('a[href^="#"]'));
   var observedTargets = navLinks.map(function (link) {
     return document.getElementById(link.hash.slice(1));

--- a/site.js
+++ b/site.js
@@ -1,0 +1,145 @@
+(function () {
+  "use strict";
+
+  document.documentElement.classList.add("js");
+
+  var body = document.body;
+  var sidebar = document.getElementById("sidebar");
+  var toggle = document.getElementById("contents-toggle");
+  var scrim = document.querySelector(".nav-scrim");
+  var backToTop = document.querySelector(".back-to-top");
+  var mobileQuery = window.matchMedia("(max-width: 900px)");
+
+  function setNavigation(open, returnFocus) {
+    body.classList.toggle("nav-open", open);
+    toggle.setAttribute("aria-expanded", String(open));
+
+    if (open) {
+      var firstLink = sidebar.querySelector("a");
+      if (firstLink) firstLink.focus();
+    } else if (returnFocus) {
+      toggle.focus();
+    }
+  }
+
+  toggle.addEventListener("click", function () {
+    setNavigation(!body.classList.contains("nav-open"), false);
+  });
+
+  scrim.addEventListener("click", function () {
+    setNavigation(false, true);
+  });
+
+  sidebar.addEventListener("click", function (event) {
+    if (mobileQuery.matches && event.target.closest("a")) {
+      setNavigation(false, false);
+    }
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape" && body.classList.contains("nav-open")) {
+      setNavigation(false, true);
+      return;
+    }
+
+    if (event.key === "Tab" && body.classList.contains("nav-open")) {
+      var sidebarLinks = sidebar.querySelectorAll("a");
+      var lastLink = sidebarLinks[sidebarLinks.length - 1];
+      if (!event.shiftKey && document.activeElement === lastLink) {
+        event.preventDefault();
+        toggle.focus();
+      } else if (event.shiftKey && document.activeElement === toggle) {
+        event.preventDefault();
+        lastLink.focus();
+      }
+    }
+  });
+
+  mobileQuery.addEventListener("change", function (event) {
+    if (!event.matches) setNavigation(false, false);
+  });
+
+  var tableWrappers = [];
+
+  document.querySelectorAll("#main-content table").forEach(function (table) {
+    if (table.parentElement.classList.contains("table-scroll")) return;
+
+    var wrapper = document.createElement("div");
+    wrapper.className = "table-scroll";
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+    tableWrappers.push(wrapper);
+  });
+
+  function updateScrollableTables() {
+    tableWrappers.forEach(function (wrapper) {
+      var isScrollable = wrapper.scrollWidth > wrapper.clientWidth + 1;
+      if (isScrollable) {
+        wrapper.tabIndex = 0;
+        wrapper.setAttribute("role", "region");
+        wrapper.setAttribute("aria-label", "Scrollable data table");
+      } else {
+        wrapper.removeAttribute("tabindex");
+        wrapper.removeAttribute("role");
+        wrapper.removeAttribute("aria-label");
+      }
+    });
+  }
+
+  window.addEventListener("resize", updateScrollableTables);
+  updateScrollableTables();
+
+  var navLinks = Array.from(sidebar.querySelectorAll('a[href^="#"]'));
+  var observedTargets = navLinks.map(function (link) {
+    return document.getElementById(link.hash.slice(1));
+  }).filter(Boolean);
+
+  function setActiveLink(id) {
+    navLinks.forEach(function (link) {
+      if (link.hash === "#" + id) {
+        link.setAttribute("aria-current", "location");
+        var linkRect = link.getBoundingClientRect();
+        var sidebarRect = sidebar.getBoundingClientRect();
+        if (linkRect.top < sidebarRect.top || linkRect.bottom > sidebarRect.bottom) {
+          link.scrollIntoView({ block: "nearest" });
+        }
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    });
+  }
+
+  if ("IntersectionObserver" in window && observedTargets.length) {
+    var visibleTargets = new Map();
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          visibleTargets.set(entry.target.id, entry.boundingClientRect.top);
+        } else {
+          visibleTargets.delete(entry.target.id);
+        }
+      });
+
+      if (visibleTargets.size) {
+        var current = Array.from(visibleTargets.entries()).sort(function (a, b) {
+          return Math.abs(a[1]) - Math.abs(b[1]);
+        })[0][0];
+        setActiveLink(current);
+      }
+    }, { rootMargin: "-15% 0px -70% 0px", threshold: 0 });
+
+    observedTargets.forEach(function (target) {
+      observer.observe(target);
+    });
+  }
+
+  function updateBackToTop() {
+    var isVisible = window.scrollY > 700;
+    backToTop.classList.toggle("is-visible", isVisible);
+    backToTop.tabIndex = isVisible ? 0 : -1;
+    backToTop.setAttribute("aria-hidden", String(!isVisible));
+  }
+
+  window.addEventListener("scroll", updateBackToTop, { passive: true });
+  updateBackToTop();
+}());

--- a/site.js
+++ b/site.js
@@ -89,6 +89,69 @@
   window.addEventListener("resize", updateScrollableTables);
   updateScrollableTables();
 
+  function markEntryHeading(element) {
+    var title = element.matches("b, strong") ? element : element.querySelector("b, strong");
+    element.classList.add("entry-heading");
+    if (title) title.classList.add("score-title");
+  }
+
+  function findEntryHeading(divider) {
+    var candidate = divider.nextElementSibling;
+    var skippedImages = 0;
+
+    while (candidate && candidate.matches("img") && skippedImages < 2) {
+      candidate = candidate.nextElementSibling;
+      skippedImages += 1;
+    }
+
+    if (!candidate) return;
+
+    if (candidate.matches("p") && candidate.querySelector("b, strong")) {
+      markEntryHeading(candidate);
+      return;
+    }
+
+    if (candidate.matches("b, strong")) {
+      markEntryHeading(candidate);
+      return;
+    }
+
+    if (candidate.matches("div")) {
+      var firstParagraph = candidate.querySelector("p");
+      if (firstParagraph && firstParagraph.querySelector("b, strong")) {
+        markEntryHeading(firstParagraph);
+      }
+    }
+  }
+
+  document.querySelectorAll("#main-content p").forEach(function (paragraph) {
+    if (!/^(?:-\s*){5,}$/.test(paragraph.textContent.trim())) return;
+
+    paragraph.classList.add("entry-divider");
+    Array.from(paragraph.childNodes).forEach(function (node) {
+      if (node.nodeType === 3 || (node.nodeType === 1 && node.tagName === "BR")) {
+        node.remove();
+      }
+    });
+    findEntryHeading(paragraph);
+  });
+
+  document.querySelectorAll("#main-content img").forEach(function (figureImage) {
+    if (figureImage.closest(".site-header") || figureImage.closest(".content-figure")) return;
+
+    var alignment = figureImage.classList.contains("right") ? "right" :
+      (figureImage.classList.contains("left") ? "left" : "");
+    var figure = document.createElement("span");
+
+    figure.className = "content-figure" + (alignment ? " content-figure--" + alignment : "");
+    figure.setAttribute("role", "figure");
+
+    figureImage.parentNode.insertBefore(figure, figureImage);
+    figureImage.classList.remove("left", "right");
+    figureImage.style.removeProperty("margin-bottom");
+    figure.appendChild(figureImage);
+  });
+
   var equationFitFrame;
 
   function fitDisplayEquations() {

--- a/site/BestStatistic.html
+++ b/site/BestStatistic.html
@@ -1,11 +1,13 @@
 <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
 <html>
 <head>
+   <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="Author" content="Beth Ebert">
    <meta name="GENERATOR" content="Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
    <title>Best statistic for measuring forecast accuracy</title>
    <link rel = "stylesheet" href="../default.css">
+   <link rel = "stylesheet" href="../reference.css">
 </head>
 <body>
 

--- a/site/BestStatistic.html
+++ b/site/BestStatistic.html
@@ -11,15 +11,11 @@
 </head>
 <body>
 
-<center>
-<h3>
-What is the best statistic for measuring the
-accuracy of a forecast?</h3></center>
-
-<center>
-<h4>
-Beth Ebert, Bureau of Meteorology Research
-Centre</h4></center>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>What is the best statistic for measuring the accuracy of a forecast?</h1>
+<p class="reference-byline">Beth Ebert, Bureau of Meteorology Research Centre</p>
+</header>
 
 <p><br>A colleague of mine used
 to ask me, "Isn't there just one statistic that would give the accuracy

--- a/site/CIdiff/FAQ-CIdiff.html
+++ b/site/CIdiff/FAQ-CIdiff.html
@@ -11,13 +11,12 @@
 </head>
 <body>
 
-<center>
-<h3>
-How do I know whether one forecast system performs significantly better
-than another?</h3></center>
-
-<center>Ian Jolliffe, University of Aberdeen<br>
-Beth Ebert, BMRC</center>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>How do I know whether one forecast system performs significantly better than another?</h1>
+<p class="reference-byline">Ian Jolliffe, University of Aberdeen<br>
+Beth Ebert, BMRC</p>
+</header>
 
 <p>First, a fair comparison between two competing forecast systems should
 ideally test on the same data, with a sample size that is large enough

--- a/site/CIdiff/FAQ-CIdiff.html
+++ b/site/CIdiff/FAQ-CIdiff.html
@@ -1,11 +1,13 @@
 <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
 <html>
 <head>
+   <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="Author" content="Beth Ebert">
    <meta name="GENERATOR" content="Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
    <title>Confidence intervals for differences</title>
    <link rel = "stylesheet" href="../../default.css">
+   <link rel = "stylesheet" href="../../reference.css">
 </head>
 <body>
 

--- a/site/Casati/statxtr.htm
+++ b/site/Casati/statxtr.htm
@@ -11,14 +11,12 @@
 
 <BODY  BGCOLOR="white"  >
 
-<center>
-<font size=6 color=black> Statistical challenges and approaches <BR> for the analysis and 
-verification/validation <BR> of weather and climate extremes </font>
-<br><br>Dr. B. Casati, Environment and Climate Change Canada, Montreal, Canada<br>
-<a href="mailto:b.casati@gmail.com">b.casati@gmail.com</a>
-</center>
-
-<BR><BR>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>Statistical challenges and approaches for the analysis and verification/validation of weather and climate extremes</h1>
+<p class="reference-byline">Dr. B. Casati, Environment and Climate Change Canada, Montreal, Canada<br>
+<a href="mailto:b.casati@gmail.com">b.casati@gmail.com</a></p>
+</header>
 
 <P> Extreme events can be defined in different ways, depending on the users and purposes of the study. 
 Extremes can be maxima or minima, they can be regarded as rare events, they can be defined by their magnitude 

--- a/site/Casati/statxtr.htm
+++ b/site/Casati/statxtr.htm
@@ -4,6 +4,8 @@
 <HTML>
 	
 <HEAD>
+	<META NAME="viewport" CONTENT="width=device-width, initial-scale=1">
+	<LINK REL="stylesheet" HREF="../../reference.css">
 	<TITLE>Statistical challenges and Approaches for the analysis and verification/validation of weather and climate extremes</TITLE>
 </HEAD>
 

--- a/site/FAQ-Hedging2.html
+++ b/site/FAQ-Hedging2.html
@@ -11,12 +11,12 @@
 </head>
 <body>
 
-<center><b><font face="Arial"><font size=+1>What does "hedging" a forecast
-mean, and how do some scores encourage hedging?</font></font></b>
-<p><b><font face="Arial">Laurie Wilson, Research en Prevision Numerique,
-Dorval, Quebec, Canada</font></b>
-<br><b><font face="Arial">Beth Ebert, Bureau of Meteorology Research Centre,
-Melbourne, Australia</font></b></center>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>What does "hedging" a forecast mean, and how do some scores encourage hedging?</h1>
+<p class="reference-byline">Laurie Wilson, Research en Prevision Numerique, Dorval, Quebec, Canada<br>
+Beth Ebert, Bureau of Meteorology Research Centre, Melbourne, Australia</p>
+</header>
 
 <p>The Oxford English dictionary defines "to hedge" as, "To avoid a definite
 decision or commitment" or "to reduce one's risk of loss on a bet or speculation

--- a/site/FAQ-Hedging2.html
+++ b/site/FAQ-Hedging2.html
@@ -1,11 +1,13 @@
 <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
 <html>
 <head>
+   <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="Generator" content="Microsoft Word 97">
    <meta name="GENERATOR" content="Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
    <title>What does "hedging" a forecast mean?</title>
    <link rel = "stylesheet" href="../default.css">
+   <link rel = "stylesheet" href="../reference.css">
 </head>
 <body>
 

--- a/site/Goeber_Wilson/Double_penalty_combined.html
+++ b/site/Goeber_Wilson/Double_penalty_combined.html
@@ -1,6 +1,7 @@
 <!doctype html PUBLIC "-//W3C//DTD html 4.0 transitional//EN">
 <html>
 <head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="generator" content="HTML Tidy, see www.w3.org">
 <meta http-equiv="Content-Type" content=
 "text/html; charset=iso-8859-1">
@@ -9,6 +10,7 @@
 "Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
 <title>Why when a model resolution is improved do the forecasts verify worse</title>
 <link rel = "stylesheet" href="../../default.css">
+<link rel = "stylesheet" href="../../reference.css">
 </head>
 <body>
 <center><h2>Why, when a model resolution is improved, do the forecasts often verify worse?</h2></center>
@@ -481,4 +483,3 @@ performance in a single diagram. <em>J. Geophys. Res.,</em>
 <b>D7, 106,</b> 7183-7192.</p>
 </body>
 </html>
-

--- a/site/Goeber_Wilson/Double_penalty_combined.html
+++ b/site/Goeber_Wilson/Double_penalty_combined.html
@@ -13,10 +13,12 @@
 <link rel = "stylesheet" href="../../reference.css">
 </head>
 <body>
-<center><h2>Why, when a model resolution is improved, do the forecasts often verify worse?</h2></center>
-<p><center>Martin Goeber and Clive Wilson, Met Office</center></p>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>Why, when a model resolution is improved, do the forecasts often verify worse?</h1>
+<p class="reference-byline">Martin Goeber and Clive Wilson, Met Office</p>
+</header>
 
-<br>
 <p>The apparently worse performance of more realistic-looking and
 more detailed forecasts compared to smoother, less realistic
 forecasts is considered from an number of viewpoints. The classic

--- a/site/Goeber_Wilson/super_obs.html
+++ b/site/Goeber_Wilson/super_obs.html
@@ -11,10 +11,11 @@
 </head>
 <body link="#0000FF">
 
-<center><h2>Comparing gridded forecasts with observations at point locations:
-<br>Use of super-observations (upscaled
-observations) for verification</h2>
-<p><b>Martin Goeber, Met Office</b></center>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>Comparing gridded forecasts with observations at point locations: use of super-observations (upscaled observations) for verification</h1>
+<p class="reference-byline">Martin Goeber, Met Office</p>
+</header>
 
 <p><b>Why?</b>
 <p>The theoretical limit of the scales represented in

--- a/site/Goeber_Wilson/super_obs.html
+++ b/site/Goeber_Wilson/super_obs.html
@@ -1,11 +1,13 @@
 <!doctype html public "-//W3C//DTD html 4.0 transitional//EN">
 <html>
 <head>
+   <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="Generator" content="Microsoft Word 97">
    <meta name="GENERATOR" content="Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
    <title>Use of super-observations (=upscaled observations) for verification</title>
    <link rel = "stylesheet" href="../../default.css">
+   <link rel = "stylesheet" href="../../reference.css">
 </head>
 <body link="#0000FF">
 

--- a/site/Inference.html
+++ b/site/Inference.html
@@ -10,8 +10,11 @@
    <link rel = "stylesheet" href="../reference.css">
 </head>
 <body>
-<b>Verification scores and
-statistical inference</b>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>Verification scores and statistical inference</h1>
+<p class="reference-byline">Ian Jolliffe, February 2003</p>
+</header>
 <p>Calculation of a verification score from a sample of forecasts and verification
 data should usually be only a first step. It should ideally be followed
 by some form of statistical inference. Even if the quality of forecasts
@@ -60,8 +63,6 @@ and prediction intervals in many circumstances. A null hypothesis will
 be rejected if and only if the null value of a population parameter lies
 outside a corresponding confidence interval, if and only if a sample score
 value lies outside a corresponding prediction interval.
-<br>&nbsp;
-<p>Ian Jolliffe, February 2003
 <p>A few other links for <b>hypothesis testing</b>:
 <p><a href="http://www.math.bcit.ca/faculty/david_sabo/apples/math2441/section9/inthyptest/introhyptest.htm">Probability
 and Statistics for Biological Sciences: Introduction to Hypothesis Testing</a>

--- a/site/Inference.html
+++ b/site/Inference.html
@@ -1,11 +1,13 @@
 <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
 <html>
 <head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="Generator" content="Microsoft Word 97">
    <meta name="GENERATOR" content="Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
    <title>Verification scores and statistical inference</title>
    <link rel = "stylesheet" href="../default.css">
+   <link rel = "stylesheet" href="../reference.css">
 </head>
 <body>
 <b>Verification scores and

--- a/site/VerificationValidation.html
+++ b/site/VerificationValidation.html
@@ -11,12 +11,11 @@
 </head>
 <body>
 
-<center>
-<h3>
-<font face="Arial,Helvetica">Is there a difference between "verification"
-and "validation"?</h3>
-<h4>
-<font face="Arial,Helvetica">Laurie Wilson, Meteorological Service of Canada</font></h4></center>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>Is there a difference between "verification" and "validation"?</h1>
+<p class="reference-byline">Laurie Wilson, Meteorological Service of Canada</p>
+</header>
 <p>
 The concise Oxford English dictionary defines "verify" as "to make sure or to demonstrate that 
 something is true, accurate or justified", from the medieval Latin <i>verificare</i>, from <i>verus</i> ("true").  
@@ -48,6 +47,5 @@ it produces accurate results.  Validation is a more general term, less quantitat
 Put more briefly:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; to validate is to check that one is doing the right things,<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; to verify is to check that one is doing things right.
-</font>
 </body>
 </html>

--- a/site/VerificationValidation.html
+++ b/site/VerificationValidation.html
@@ -1,11 +1,13 @@
 <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
 <html>
 <head>
+   <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
    <meta name="Author" content="Beth Ebert">
    <meta name="GENERATOR" content="Mozilla/4.79 [en] (Windows NT 5.0; U) [Netscape]">
    <title>Verification and validation</title>
    <link rel = "stylesheet" href="../default.css">
+   <link rel = "stylesheet" href="../reference.css">
 </head>
 <body>
 

--- a/site/WordedForecasts.html
+++ b/site/WordedForecasts.html
@@ -1,10 +1,12 @@
 <HTML>
 <HEAD>
+<META NAME="viewport" CONTENT="width=device-width, initial-scale=1">
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=windows-1252">
 <META NAME="Generator" CONTENT="Microsoft Word 97">
 <TITLE>How do I verify worded forecasts</TITLE>
 <META NAME="Template" CONTENT="C:\Program Files\Microsoft Office\Office\html.dot">
 <link rel = "stylesheet" href="../default.css">
+<link rel = "stylesheet" href="../reference.css">
 </HEAD>
 <BODY LINK="#0000ff" VLINK="#800080">
 

--- a/site/WordedForecasts.html
+++ b/site/WordedForecasts.html
@@ -10,9 +10,12 @@
 </HEAD>
 <BODY LINK="#0000ff" VLINK="#800080">
 
-<B><FONT SIZE=4><P ALIGN="CENTER">How do I verify worded forecasts?</P>
-</FONT><P ALIGN="CENTER">Ian Jolliffe, University of Aberdeen</P>
-</B><P ALIGN="JUSTIFY">The simple answer to this question is "with difficulty and with caution". A sample of 
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../index.html#FAQs">Forecast Verification FAQ</a>
+<h1>How do I verify worded forecasts?</h1>
+<p class="reference-byline">Ian Jolliffe, University of Aberdeen</p>
+</header>
+<P ALIGN="JUSTIFY">The simple answer to this question is "with difficulty and with caution". A sample of
 extracts from worded forecasts is "a shower or two but mainly fine", "best of sunshine in southeast", 
 "partly cloudy", "le temps restera tr&egrave;s orageux sur le sud Auvergne". These are taken from Australia, 
 the UK, the USA and France on one day in July 2003. What is common to all is that the forecast as it stands 

--- a/site/reliability_resolution.html
+++ b/site/reliability_resolution.html
@@ -1,6 +1,8 @@
 <html>
 <head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel = "stylesheet" href="../default.css">
+<link rel = "stylesheet" href="../reference.css">
   <!-- MathJax for rendering mathematical equations -->
   <script id="MathJax-script" async
     src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js"

--- a/site/reliability_resolution.html
+++ b/site/reliability_resolution.html
@@ -11,11 +11,11 @@
 </head>
 <body>
 
-<center>
-<h3><i>Reliability</i> and <i>resolution</i> - how are they different?</h3>
-<p>
-Yuejian Zhu, NCEP and Beth Ebert, CAWCR
-</p></center>
+<header class="reference-header">
+<a class="reference-breadcrumb" href="../index.html#FAQs">Forecast Verification FAQ</a>
+<h1><i>Reliability</i> and <i>resolution</i> - how are they different?</h1>
+<p class="reference-byline">Yuejian Zhu, NCEP and Beth Ebert, CAWCR</p>
+</header>
 
 <p>Reliability and resolution are two independent attributes of a forecast. 
 <i>Reliability</i> is concerned only with the statistical consistency between each class of forecasts 


### PR DESCRIPTION
While nobody was updating the actual content, I thought that it would be a good opportunity to update the style of the web page to make it look a little more modern.

In this pull request, there are no changes to the content. There are only changes to the website design.

A summary of the changes:
- Improved typography, spacing, colours, headings, and page layout for easier reading.
- Added responsive navigation and improved behaviour on mobile and smaller screens.
- Replaced dashed score separators with clearer section rules and consistent score headings.
- Styled the existing example results as pale-teal callouts.
- Automatically scales long equations so they fit the available width without requiring manual line breaks.
- Improved table presentation and reduced unnecessary horizontal scrolling.
- Standardised the ten linked FAQ pages with consistent styling, page headers, author information, spacing, and breadcrumbs back to the FAQ section.
- Removed legacy blue text that was inconsistent with the rest of the website.